### PR TITLE
Support disabling networking for created containers

### DIFF
--- a/cmd/collector/custom.go
+++ b/cmd/collector/custom.go
@@ -72,6 +72,7 @@ func doFlags() {
 		collector.LocalHost = true
 	}
 	//nextMaxImages = *maxImages
+	config.NetworkDisabled = *networkDisabled
 }
 
 func printExampleUsage() {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -34,6 +34,7 @@ var (
 		"List of previously collected images (file)")
 	repoList = flag.String([]string{"r", "-repolist"}, config.BANYANDIR()+"/hostcollector/repolist",
 		"File containing list of repos to process")
+	networkDisabled = flag.Bool([]string{"-networkdisabled"}, false, "Disable networking for created containers")
 
 	// Configuration parameters for speed/efficiency
 	removeThresh = flag.Int([]string{"-removethresh"}, 5,

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,8 @@ const (
 )
 
 var (
-	FilterRepos = false
+	FilterRepos     = false
+	NetworkDisabled = false
 
 	// Directories/files dependent on Environment variables
 	BANYANHOSTDIR = func() string {

--- a/dockerRemote.go
+++ b/dockerRemote.go
@@ -47,17 +47,18 @@ type HostConfig struct {
 }
 
 type ContainerConfig struct {
-	User         string
-	AttachStdin  bool
-	AttachStdout bool
-	AttachStderr bool
-	Tty          bool
-	Env          []string
-	Cmd          []string
-	Entrypoint   []string
-	Image        string
-	Labels       map[string]string
-	WorkingDir   string
+	User            string
+	AttachStdin     bool
+	AttachStdout    bool
+	AttachStderr    bool
+	Tty             bool
+	Env             []string
+	Cmd             []string
+	Entrypoint      []string
+	Image           string
+	Labels          map[string]string
+	WorkingDir      string
+	NetworkDisabled bool
 }
 
 type Container struct {
@@ -248,6 +249,7 @@ func createCmd(imageID ImageIDType, scriptName, staticBinary, dirPath string) (j
 	container.User = "0"
 	container.AttachStdout = true
 	container.AttachStderr = true
+	container.NetworkDisabled = config.NetworkDisabled
 	container.HostConfig.Binds = []string{config.BANYANHOSTDIR() + "/hosttarget" + ":" + TARGETCONTAINERDIR + ":ro"}
 	container.Image = string(imageID)
 


### PR DESCRIPTION
Provide a command line flag for starting all containers with networking
disabled.

This functionality is mentioned in issue #9
